### PR TITLE
Update package.json - Make sure to use clean-css >= 3.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coveralls": "${npm_package_scripts_coverage} && istanbul-coveralls"
   },
   "dependencies": {
-    "clean-css": "^3.3.3",
+    "clean-css": "^3.4.8",
     "gulp-util": "^3.0.5",
     "object-assign": "^4.0.1",
     "readable-stream": "^2.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -133,7 +133,7 @@ describe('gulp-minify-css source map', function() {
 
     const write = sourceMaps.write()
     .on('data', file => {
-      const expected = '/*! header */p{text-align:center}b,p{color:#0ff}\n';
+      const expected = '/*! header */p{text-align:center}b,p{color:#0ff}\n\n';
       expect(String(file.contents).replace(/\/\*#.*/, '')).to.be.equal(expected);
       expect(file.sourceMap.mappings).to.be.equal('aAAA,EACE,WAAY,OCDd,ECIA,EDJI,MAAO');
 


### PR DESCRIPTION
jakubpawlowicz/clean-css#676 is a pretty severe bug in clean-css that has bitten quite a lot of people.
This PR makes sure that everyone uses a version >= 3.4.8 (which has a fix)

https://www.npmjs.com/package/clean-css